### PR TITLE
Fixed CultureInfo problems when parsing decimals from map file

### DIFF
--- a/Sledge.DataStructures/Geometric/Coordinate.cs
+++ b/Sledge.DataStructures/Geometric/Coordinate.cs
@@ -237,7 +237,7 @@ namespace Sledge.DataStructures.Geometric
         public static Coordinate Parse(string x, string y, string z)
         {
             const NumberStyles ns = NumberStyles.Float;
-            return new Coordinate(decimal.Parse(x, ns), decimal.Parse(y, ns), decimal.Parse(z, ns));
+            return new Coordinate(decimal.Parse(x, ns, CultureInfo.InvariantCulture), decimal.Parse(y, ns, CultureInfo.InvariantCulture), decimal.Parse(z, ns, CultureInfo.InvariantCulture));
         }
 
         public CoordinateF ToCoordinateF()

--- a/Sledge.Providers/Map/MapFormatProvider.cs
+++ b/Sledge.Providers/Map/MapFormatProvider.cs
@@ -75,12 +75,12 @@ namespace Sledge.Providers.Map
                                {
                                    Name = parts[15],
                                    UAxis = Coordinate.Parse(parts[17], parts[18], parts[19]),
-                                   XShift = decimal.Parse(parts[20], ns),
+                                   XShift = decimal.Parse(parts[20], ns,CultureInfo.InvariantCulture),
                                    VAxis = Coordinate.Parse(parts[23], parts[24], parts[25]),
-                                   YShift = decimal.Parse(parts[26], ns),
-                                   Rotation = decimal.Parse(parts[28], ns),
-                                   XScale = decimal.Parse(parts[29], ns),
-                                   YScale = decimal.Parse(parts[30], ns)
+                                   YShift = decimal.Parse(parts[26], ns, CultureInfo.InvariantCulture),
+                                   Rotation = decimal.Parse(parts[28], ns, CultureInfo.InvariantCulture),
+                                   XScale = decimal.Parse(parts[29], ns, CultureInfo.InvariantCulture),
+                                   YScale = decimal.Parse(parts[30], ns, CultureInfo.InvariantCulture)
                                }
                        };
         }


### PR DESCRIPTION
This fixes a problem that threw an exception when parsing coordinates and other decimals from .map files due to different culture where the decimal separator is different than '.'
