### PR TITLE
FGD Multiple Color Behaviour problem

### DIFF
--- a/Sledge.DataStructures/MapObjects/Entity.cs
+++ b/Sledge.DataStructures/MapObjects/Entity.cs
@@ -103,7 +103,7 @@ namespace Sledge.DataStructures.MapObjects
             {
                 if (GameData != null && GameData.ClassType == ClassType.Point)
                 {
-                    var behav = GameData.Behaviours.SingleOrDefault(x => x.Name == "color");
+                    var behav = GameData.Behaviours.LastOrDefault(x => x.Name == "color");
                     if (behav != null && behav.Values.Count == 3)
                     {
                         return behav.GetColour(0);


### PR DESCRIPTION
In sven-coop.fgd (4.8), env_global has set 2 behaviours for "color". Hammer behaviour to this appears to use the last one, in Sledge currently it throws an exception because there's more than 1. This fix will make it use the last one.
