### PR TITLE
Fix texture lock when doing Shift+Drag to clone brushes

### DIFF
--- a/Sledge.Editor/Tools/SelectTool/SelectTool.cs
+++ b/Sledge.Editor/Tools/SelectTool/SelectTool.cs
@@ -923,6 +923,11 @@ namespace Sledge.Editor.Tools.SelectTool
             {
                 // Copy the selection, transform it, and reselect
                 var copies = ClipboardManager.CloneFlatHeirarchy(Document, Document.Selection.GetSelectedObjects()).ToList();
+                // HACK: Load textures now so Face.Transform() texture lock code works
+                foreach (var face in copies.SelectMany(x => x.FindAll().OfType<Solid>().SelectMany(y => y.Faces)))
+                {
+                    face.Texture.Texture = Document.GetTexture(face.Texture.Name);
+                }
                 foreach (var mo in copies)
                 {
                     mo.Transform(transform, Document.Map.GetTransformFlags());


### PR DESCRIPTION
I noticed that doing Shift+Drag to clone brushes with the Select Tool wasn't using texture lock, even if texture lock was enabled.

The cause was, face.Texture.Texture was null when the transformation was applied to the cloned brushes. I copied this from OperationsPasteSpecial()... doesn't feel like a great fix, but at least it's something.