### PR TITLE
Better WAD2 implementation

### DIFF
--- a/Sledge.DataStructures/GameData/Palette.cs
+++ b/Sledge.DataStructures/GameData/Palette.cs
@@ -1,0 +1,12 @@
+﻿namespace Sledge.DataStructures.GameData
+{
+    public class Palette
+    {
+        public byte[] ByteArray { get; private set; }
+
+        public Palette(byte[] pal)
+        {
+            ByteArray = pal;
+        }
+    }
+}

--- a/Sledge.DataStructures/Sledge.DataStructures.csproj
+++ b/Sledge.DataStructures/Sledge.DataStructures.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="GameData\AutoVisgroup.cs" />
     <Compile Include="GameData\AutoVisgroupSection.cs" />
+    <Compile Include="GameData\Palette.cs" />
     <Compile Include="Geometric\Box.cs" />
     <Compile Include="Geometric\Cloud.cs" />
     <Compile Include="Geometric\CoordinateF.cs" />

--- a/Sledge.Editor/Documents/Document.cs
+++ b/Sledge.Editor/Documents/Document.cs
@@ -44,6 +44,7 @@ namespace Sledge.Editor.Documents
         public Game Game { get; set; }
         public GameEnvironment Environment { get; private set; }
         public GameData GameData { get; set; }
+        public Palette Palette { get; set; }
 
         public Pointfile Pointfile { get; set; }
 
@@ -107,7 +108,25 @@ namespace Sledge.Editor.Documents
                 GameData.MapSizeHigh = game.OverrideMapSizeHigh;
             }
 
-            TextureCollection = TextureProvider.CreateCollection(Environment.GetGameDirectories(), Game.AdditionalPackages, Game.GetTextureBlacklist(), Game.GetTextureWhitelist());
+            // Set up Quake 1/Hexen 2 palette
+            var palpath = Environment.Root.TraversePath("gfx/palette.lmp");
+            var paldata = new byte[768];
+            if (palpath != null)
+            {
+                try
+                {
+                    using (var br = new BinaryReader(palpath.Open()))
+                    {
+                        paldata = br.ReadBytes(768);
+                    }
+                }
+                catch (Exception)
+                {
+                }
+            }
+            Palette = new Palette(paldata);
+            
+            TextureCollection = TextureProvider.CreateCollection(Environment.GetGameDirectories(), Game.AdditionalPackages, Game.GetTextureBlacklist(), Game.GetTextureWhitelist(), Palette);
             /* .Union(GameData.MaterialExclusions) */ // todo material exclusions
 
             var texList = Map.GetAllTextures();

--- a/Sledge.Editor/Extensions/ModelExtensions.cs
+++ b/Sledge.Editor/Extensions/ModelExtensions.cs
@@ -83,7 +83,7 @@ namespace Sledge.Editor.Extensions
 
                 try
                 {
-                    var mr = ModelProvider.CreateModelReference(file);
+                    var mr = ModelProvider.CreateModelReference(file, document.Palette);
                     SetModel(e, mr);
                     cache.Add(model, mr);
                     return true;

--- a/Sledge.Packages/Sledge.Packages.csproj
+++ b/Sledge.Packages/Sledge.Packages.csproj
@@ -58,7 +58,12 @@
     <Compile Include="Wad\WadPackage.cs" />
     <Compile Include="Wad\WadPackageStreamSource.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\Sledge.DataStructures\Sledge.DataStructures.csproj">
+      <Project>{26a974c9-e495-4fa3-8e87-1e00019d04f5}</Project>
+      <Name>Sledge.DataStructures</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Sledge.Packages/Wad/WadEntryType.cs
+++ b/Sledge.Packages/Wad/WadEntryType.cs
@@ -7,7 +7,7 @@ namespace Sledge.Packages.Wad
         // ColorMap = 0x41,
         Image = 0x42, // Simple image with any size
         Texture = 0x43, // Power-of-16-sized world textures with 4 mipmaps
-        // Raw = 0x44,
+        QuakeTexture = 0x44, // Same as Texture but without the palette following the mipmaps
         // ColorMap2 = 0x45,
         // Font = 0x46, // Fixed-height font. Contains an image and font data (row, X offset and width of a character) for 256 ASCII characters. 
     }

--- a/Sledge.Packages/Wad/WadImageStream.cs
+++ b/Sledge.Packages/Wad/WadImageStream.cs
@@ -81,8 +81,17 @@ namespace Sledge.Packages.Wad
                 bw.Write(_entry.PaletteSize); // Colours used
                 bw.Write(_entry.PaletteSize); // "Important" colours used
 
-                br.BaseStream.Position = startIndex + (_entry.PaletteDataOffset - _entry.Offset);
-                var paletteData = br.ReadBytes((int)(_entry.PaletteSize * 3));
+                byte[] paletteData;
+                if (_entry.Type == WadEntryType.QuakeTexture)
+                {
+                    paletteData = _entry.Package.Palette.ByteArray;
+                }
+                else
+                {
+                    br.BaseStream.Position = startIndex + (_entry.PaletteDataOffset - _entry.Offset);
+                    paletteData = br.ReadBytes((int)(_entry.PaletteSize * 3));
+                }
+
                 for (var i = 0; i < _entry.PaletteSize; i++)
                 {
                     // Wad palettes are RGB, bitmap is BGRX

--- a/Sledge.Providers/Model/MdlProvider.cs
+++ b/Sledge.Providers/Model/MdlProvider.cs
@@ -39,19 +39,19 @@ namespace Sledge.Providers.Model
             return file.Extension.ToLowerInvariant() == "mdl";
         }
 
-        protected override DataStructures.Models.Model LoadFromFile(IFile file)
+        protected override DataStructures.Models.Model LoadFromFile(IFile file, DataStructures.GameData.Palette pal)
         {
-            return LoadMDL(file, ModelLoadItems.AllStatic | ModelLoadItems.Animations);
+            return LoadMDL(file, ModelLoadItems.AllStatic | ModelLoadItems.Animations, pal);
         }
 
         // Model loader for MDL files. Reference Valve's studiohdr_t struct definition for the most part.
-        public DataStructures.Models.Model LoadMDL(IFile file, ModelLoadItems loadItems)
+        public DataStructures.Models.Model LoadMDL(IFile file, ModelLoadItems loadItems, DataStructures.GameData.Palette pal)
         {
             using (var fs = new MemoryStream(file.ReadAll()))
             {
                 using(var br = new BinaryReader(fs))
                 {
-                    return ReadModel(br, file, loadItems);
+                    return ReadModel(br, file, loadItems, pal);
                 }
             }
         }
@@ -73,7 +73,7 @@ namespace Sledge.Providers.Model
         private const byte VTXStripGroupTriListFlag = 0x01;
         private const byte VTXStripGroupTriStripFlag = 0x02;
 
-        private static DataStructures.Models.Model ReadModel(BinaryReader br, IFile file, ModelLoadItems loadItems)
+        private static DataStructures.Models.Model ReadModel(BinaryReader br, IFile file, ModelLoadItems loadItems, DataStructures.GameData.Palette pal)
         {
             // int id - Not really an int. This is a magic string, either "IDST" or "IDSQ".
             var magicString = br.ReadFixedLengthString(Encoding.UTF8, 4);

--- a/Sledge.Providers/Model/ModelProvider.cs
+++ b/Sledge.Providers/Model/ModelProvider.cs
@@ -37,9 +37,9 @@ namespace Sledge.Providers.Model
             RegisteredProviders.Clear();
         }
 
-        public static ModelReference CreateModelReference(IFile file)
+        public static ModelReference CreateModelReference(IFile file, DataStructures.GameData.Palette pal)
         {
-            var model = LoadModel(file);
+            var model = LoadModel(file, pal);
             var reference = new ModelReference(file.FullPathName, model);
             References.Add(reference);
             return reference;
@@ -59,7 +59,7 @@ namespace Sledge.Providers.Model
             return RegisteredProviders.Any(p => p.IsValidForFile(file));
         }
 
-        private static DataStructures.Models.Model LoadModel(IFile file)
+        private static DataStructures.Models.Model LoadModel(IFile file, DataStructures.GameData.Palette pal)
         {
             var path = file.FullPathName;
             if (Models.ContainsKey(path)) return Models[path];
@@ -68,7 +68,7 @@ namespace Sledge.Providers.Model
             var provider = RegisteredProviders.FirstOrDefault(p => p.IsValidForFile(file));
             if (provider != null)
             {
-                var model = provider.LoadFromFile(file);
+                var model = provider.LoadFromFile(file, pal);
                 model.PreprocessModel();
                 for (var i = 0; i < model.Textures.Count; i++)
                 {
@@ -88,6 +88,6 @@ namespace Sledge.Providers.Model
         }
 
         protected abstract bool IsValidForFile(IFile file);
-        protected abstract DataStructures.Models.Model LoadFromFile(IFile file);
+        protected abstract DataStructures.Models.Model LoadFromFile(IFile file, DataStructures.GameData.Palette pal);
     }
 }

--- a/Sledge.Providers/Texture/SprProvider.cs
+++ b/Sledge.Providers/Texture/SprProvider.cs
@@ -9,6 +9,7 @@ using System.Text;
 using Sledge.Common;
 using Sledge.FileSystem;
 using Sledge.Graphics.Helpers;
+using Sledge.DataStructures.GameData;
 
 namespace Sledge.Providers.Texture
 {
@@ -137,11 +138,11 @@ namespace Sledge.Providers.Texture
             }
         }
 
-        public override IEnumerable<TexturePackage> CreatePackages(IEnumerable<string> sourceRoots, IEnumerable<string> additionalPackages, IEnumerable<string> blacklist, IEnumerable<string> whitelist)
+        public override IEnumerable<TexturePackage> CreatePackages(IEnumerable<string> sourceRoots, IEnumerable<string> additionalPackages, IEnumerable<string> blacklist, IEnumerable<string> whitelist, Palette pal)
         {
             // Sprite provider ignores the black/whitelists
             var dirs = sourceRoots.Union(additionalPackages).Where(Directory.Exists).Select(Path.GetFullPath).Select(x => x.ToLowerInvariant()).Distinct().ToList();
-            var tp = new TexturePackage(String.Join(";", dirs), "sprites", this) {IsBrowsable = false};
+            var tp = new TexturePackage(String.Join(";", dirs), "sprites", this, pal) {IsBrowsable = false};
             foreach (var dir in dirs)
             {
                 var sprs = Directory.GetFiles(dir, "*.spr", SearchOption.AllDirectories);

--- a/Sledge.Providers/Texture/TexturePackage.cs
+++ b/Sledge.Providers/Texture/TexturePackage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Sledge.Graphics.Helpers;
+using Sledge.DataStructures.GameData;
 
 namespace Sledge.Providers.Texture
 {
@@ -12,8 +13,9 @@ namespace Sledge.Providers.Texture
         public Dictionary<string, TextureItem> Items { get; private set; }
         private readonly Dictionary<string, TextureItem> _loadedItems;
         public bool IsBrowsable { get; set; }
+        public Palette Palette { get; private set; }
 
-        public TexturePackage(string packageRoot, string packageRelativePath, TextureProvider provider)
+        public TexturePackage(string packageRoot, string packageRelativePath, TextureProvider provider, Palette pal)
         {
             Provider = provider;
             PackageRoot = packageRoot;
@@ -21,6 +23,7 @@ namespace Sledge.Providers.Texture
             Items = new Dictionary<string, TextureItem>();
             _loadedItems = new Dictionary<string, TextureItem>();
             IsBrowsable = true;
+            Palette = pal;
         }
 
         public void AddTexture(TextureItem item)

--- a/Sledge.Providers/Texture/TextureProvider.cs
+++ b/Sledge.Providers/Texture/TextureProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Sledge.Graphics.Helpers;
+using Sledge.DataStructures.GameData;
 
 namespace Sledge.Providers.Texture
 {
@@ -41,12 +42,12 @@ namespace Sledge.Providers.Texture
         #endregion
 
         protected string CachePath { get; private set; }
-        public abstract IEnumerable<TexturePackage> CreatePackages(IEnumerable<string> sourceRoots, IEnumerable<string> additionalPackages, IEnumerable<string> blacklist, IEnumerable<string> whitelist);
+        public abstract IEnumerable<TexturePackage> CreatePackages(IEnumerable<string> sourceRoots, IEnumerable<string> additionalPackages, IEnumerable<string> blacklist, IEnumerable<string> whitelist, Palette pal);
         public abstract void DeletePackages(IEnumerable<TexturePackage> packages);
         public abstract void LoadTextures(IEnumerable<TextureItem> items);
         public abstract ITextureStreamSource GetStreamSource(int maxWidth, int maxHeight, IEnumerable<TexturePackage> packages);
 
-        public static TextureCollection CreateCollection(IEnumerable<string> sourceRoots, IEnumerable<string> additionalPackages, IEnumerable<string> blacklist, IEnumerable<string> whitelist)
+        public static TextureCollection CreateCollection(IEnumerable<string> sourceRoots, IEnumerable<string> additionalPackages, IEnumerable<string> blacklist, IEnumerable<string> whitelist, Palette pal)
         {
             var list = sourceRoots.ToList();
             var additional = additionalPackages == null ? new List<string>() : additionalPackages.ToList();
@@ -55,7 +56,7 @@ namespace Sledge.Providers.Texture
             var pkgs = new List<TexturePackage>();
             foreach (var provider in RegisteredProviders)
             {
-                pkgs.AddRange(provider.CreatePackages(list, additional, bl, wl));
+                pkgs.AddRange(provider.CreatePackages(list, additional, bl, wl, pal));
             }
             var tc = new TextureCollection(pkgs);
             Packages.AddRange(pkgs);

--- a/Sledge.Providers/Texture/VmtProvider.cs
+++ b/Sledge.Providers/Texture/VmtProvider.cs
@@ -8,6 +8,7 @@ using Sledge.Common;
 using Sledge.Graphics.Helpers;
 using Sledge.Packages;
 using Sledge.Packages.Vpk;
+using Sledge.DataStructures.GameData;
 
 namespace Sledge.Providers.Texture
 {
@@ -15,7 +16,7 @@ namespace Sledge.Providers.Texture
     {
         private readonly Dictionary<TexturePackage, QuickRoot> _roots = new Dictionary<TexturePackage, QuickRoot>();
 
-        public override IEnumerable<TexturePackage> CreatePackages(IEnumerable<string> sourceRoots, IEnumerable<string> additionalPackages, IEnumerable<string> blacklist, IEnumerable<string> whitelist)
+        public override IEnumerable<TexturePackage> CreatePackages(IEnumerable<string> sourceRoots, IEnumerable<string> additionalPackages, IEnumerable<string> blacklist, IEnumerable<string> whitelist, Palette pal)
         {
             var blist = blacklist.Select(x => x.TrimEnd('/', '\\')).Where(x => !String.IsNullOrWhiteSpace(x)).ToList();
             var wlist = whitelist.Select(x => x.TrimEnd('/', '\\')).Where(x => !String.IsNullOrWhiteSpace(x)).ToList();
@@ -59,7 +60,7 @@ namespace Sledge.Providers.Texture
                     continue;
                 }
 
-                if (!packages.ContainsKey(dir)) packages.Add(dir, new TexturePackage(packageRoot, dir, this));
+                if (!packages.ContainsKey(dir)) packages.Add(dir, new TexturePackage(packageRoot, dir, this, pal));
                 if (packages[dir].HasTexture(vmt)) continue;
 
                 var gs = GenericStructure.Parse(new StreamReader(vmtRoot.OpenFile(vmt))).FirstOrDefault();

--- a/Sledge.Tests/Vtf/VtfTest.cs
+++ b/Sledge.Tests/Vtf/VtfTest.cs
@@ -91,7 +91,7 @@ namespace Sledge.Tests.Vtf
             var collection = TextureProvider.CreateCollection(new[]
             {
                 @"F:\Steam\SteamApps\common\Team Fortress 2\tf"
-            }, null, null, null);
+            }, null, null, null, null);
         }
 
         [TestMethod]


### PR DESCRIPTION
- Supports quake and hexen 2 (they both use WAD2, with the palette in gfx/palette.lmp, but the palette colors are different)
- Handles different open documents using different palettes correctly
- If you change the gamedir in the game configuration, the palette isn't reloaded until you close/reopen the document, or open a new document

I didn't add anything to disable this code if the game is GoldSrc; it always tries to load gfx/palette.lmp in the Document constructor, but this could be surrounded by a check for the game engine type. 