### PR TITLE
Allow loading .png and .jpg textures from .pk3s

### DIFF
--- a/Sledge.Editor/Editor.cs
+++ b/Sledge.Editor/Editor.cs
@@ -143,6 +143,7 @@ namespace Sledge.Editor
             TextureProvider.Register(new WadProvider());
             TextureProvider.Register(new SprProvider());
             TextureProvider.Register(new VmtProvider());
+            TextureProvider.Register(new ZipProvider());
             ModelProvider.Register(new MdlProvider());
 
             WadProvider.ReplaceTransparentPixels = !Sledge.Settings.View.DisableWadTransparency && !Sledge.Settings.View.GloballyDisableTransparency;

--- a/Sledge.FileSystem/InlinePackageFile.cs
+++ b/Sledge.FileSystem/InlinePackageFile.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using Sledge.Packages;
 using Sledge.Packages.Pak;
 using Sledge.Packages.Vpk;
+using Sledge.Packages.Zip;
 
 namespace Sledge.FileSystem
 {
@@ -28,6 +29,9 @@ namespace Sledge.FileSystem
             {
                 case ".pak":
                     _package = new PakPackage(new FileInfo(fileName));
+                    break;
+                case ".pk3":
+                    _package = new ZipPackage(new FileInfo(fileName));
                     break;
                 case ".vpk":
                     _package = new VpkDirectory(new FileInfo(fileName));

--- a/Sledge.FileSystem/NativeFile.cs
+++ b/Sledge.FileSystem/NativeFile.cs
@@ -122,8 +122,9 @@ namespace Sledge.FileSystem
         {
             if (_packages != null) return;
             var paks = DirectoryInfo.GetFiles("*.pak").Select(x => new InlinePackageFile(x.FullName)).ToList();
+            var pk3s = DirectoryInfo.GetFiles("*.pk3").Select(x => new InlinePackageFile(x.FullName)).ToList();
             var vpks = DirectoryInfo.GetFiles("*_dir.vpk").Select(x => new InlinePackageFile(x.FullName)).ToList();
-            _packages = paks.Union(vpks).ToList();
+            _packages = paks.Union(pk3s).Union(vpks).ToList();
         }
 
         public IFile GetChild(string name)

--- a/Sledge.Packages/Sledge.Packages.csproj
+++ b/Sledge.Packages/Sledge.Packages.csproj
@@ -19,6 +19,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -27,10 +28,12 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -45,6 +48,10 @@
     <Compile Include="Pak\PakPackage.cs" />
     <Compile Include="Pak\PakEntry.cs" />
     <Compile Include="Pak\PakPackageStreamSource.cs" />
+    <Compile Include="Zip\ZipArchive.cs" />
+    <Compile Include="Zip\ZipEntry.cs" />
+    <Compile Include="Zip\ZipPackage.cs" />
+    <Compile Include="Zip\ZipPackageStreamSource.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PackageException.cs" />
     <Compile Include="SubStream.cs" />

--- a/Sledge.Packages/Zip/ZipArchive.cs
+++ b/Sledge.Packages/Zip/ZipArchive.cs
@@ -1,0 +1,239 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Sledge.Packages.Zip
+{
+	public class ZipArchive : IDisposable
+	{
+		private List<ZipEntry> _entries;
+		private Dictionary<string, FileEntry> _files;
+		private MemoryStream _stream;
+
+		public string Path { get; set; }
+
+		public ZipArchive(MemoryStream stream)
+		{
+			_entries = new List<ZipEntry>();
+			_stream = stream;
+			var br = new BinaryReader(_stream, Encoding.UTF8);
+			//using ()
+			{
+				ZipEntry entry;
+				do
+				{
+					entry = ReadEntry(br);
+					_entries.Add(entry);
+				} while (entry != null && entry.Type != ZipEntryType.EndOfCentralDirectory);
+				_files = _entries.OfType<FileEntry>().ToDictionary(x => x.FileName, x => x);
+			}
+			_stream.Seek(0, SeekOrigin.Begin);
+		}
+
+		public void Dispose()
+		{
+			_stream.Dispose();
+		}
+
+		public IEnumerable<string> GetDirectories()
+		{
+			return _files.Where(x => x.Value.UncompressedSize == 0).Select(x => x.Key);
+		}
+
+		public IEnumerable<string> GetFiles()
+		{
+			return _files.Where(x => x.Value.UncompressedSize > 0).Select(x => x.Key);
+		}
+
+		public MemoryStream GetFileStream(string path)
+		{
+			var file = _files[path];
+			return file.GetStream(_stream);
+		}
+
+		private ZipEntry ReadEntry(BinaryReader br)
+		{
+			var type = (ZipEntryType)br.ReadUInt32();
+			br.BaseStream.Seek(-4, SeekOrigin.Current);
+			switch (type)
+			{
+				case ZipEntryType.File:
+					return new FileEntry(br);
+				case ZipEntryType.DataDescriptor:
+					return new DataDescriptorEntry(br);
+				case ZipEntryType.CentralDirectory:
+					return new CentralDirectoryEntry(br);
+				case ZipEntryType.EndOfCentralDirectory:
+					return new EndOfCentralDirectoryEntry(br);
+			}
+			throw new NotSupportedException("Unknown entry type: " + ((uint)type).ToString("X"));
+		}
+
+		private class ZipEntry
+		{
+			public long Offset { get; set; }
+			public ZipEntryType Type { get; set; }
+		}
+
+		private class FileEntry : ZipEntry
+		{
+			public CompressionMethod CompressionMethod { get; set; }
+			public uint CompressedSize { get; set; }
+			public uint UncompressedSize { get; set; }
+			public string FileName { get; set; }
+			public long DataStartOffset { get; set; }
+
+			public FileEntry(BinaryReader br)
+			{
+				Offset = br.BaseStream.Position;
+				Type = ZipEntryType.File;
+
+				if (br.ReadUInt32() != (uint)ZipEntryType.File) throw new Exception("ZIP header is incorrect");
+				br.BaseStream.Seek(4, SeekOrigin.Current);
+				CompressionMethod = (CompressionMethod)br.ReadUInt16();
+				br.BaseStream.Seek(8, SeekOrigin.Current);
+				CompressedSize = br.ReadUInt32();
+				UncompressedSize = br.ReadUInt32();
+				var fileNameLength = br.ReadUInt16();
+				var extraLength = br.ReadUInt16();
+				FileName = new string(br.ReadChars(fileNameLength));
+				br.BaseStream.Seek(extraLength, SeekOrigin.Current);
+				DataStartOffset = br.BaseStream.Position;
+				br.BaseStream.Seek(CompressedSize, SeekOrigin.Current);
+			}
+
+			public MemoryStream GetStream(MemoryStream container)
+			{
+				byte[] bytesOut = new byte[UncompressedSize];
+				var oldPos = 0L;
+                switch (CompressionMethod)
+				{
+					case CompressionMethod.None:
+
+						oldPos = container.Position;
+						container.Position = DataStartOffset;
+						container.Read(bytesOut, 0, (int)CompressedSize);
+						container.Position = oldPos;
+						return new MemoryStream(bytesOut);
+					//return new SubStream(container, DataStartOffset, CompressedSize);
+					case CompressionMethod.Deflate:
+
+						byte[] bytesIn = new byte[CompressedSize];
+						oldPos = container.Position;
+						container.Position = DataStartOffset;
+                        container.Read(bytesIn, 0, (int)CompressedSize);
+						MemoryStream bytesInMemoryStream = new MemoryStream(bytesIn);
+						var rtn = new System.IO.Compression.DeflateStream(bytesInMemoryStream, System.IO.Compression.CompressionMode.Decompress, true);
+						rtn.Read(bytesOut, 0, (int)UncompressedSize);
+						var ms = new MemoryStream(bytesOut);
+						container.Position = oldPos;
+						return ms;
+					default:
+						throw new NotSupportedException("This zip compression method (" + CompressionMethod + ") is not supported.");
+				}
+			}
+		}
+
+		private class DataDescriptorEntry : ZipEntry
+		{
+			public uint CompressedSize { get; set; }
+			public uint UncompressedSize { get; set; }
+
+			public DataDescriptorEntry(BinaryReader br)
+			{
+				Offset = br.BaseStream.Position;
+				Type = ZipEntryType.DataDescriptor;
+
+				if (br.ReadUInt32() != (uint)ZipEntryType.DataDescriptor) throw new Exception("ZIP header is incorrect");
+
+				var crc = br.ReadUInt32();
+				CompressedSize = br.ReadUInt32();
+				UncompressedSize = br.ReadUInt32();
+			}
+		}
+
+		private class CentralDirectoryEntry : ZipEntry
+		{
+			public CompressionMethod CompressionMethod { get; set; }
+			public uint CompressedSize { get; set; }
+			public uint UncompressedSize { get; set; }
+			public string FileName { get; set; }
+			public uint FileOffset { get; set; }
+
+			public CentralDirectoryEntry(BinaryReader br)
+			{
+				Offset = br.BaseStream.Position;
+				Type = ZipEntryType.CentralDirectory;
+
+				if (br.ReadUInt32() != (uint)ZipEntryType.CentralDirectory) throw new Exception("ZIP header is incorrect");
+				br.BaseStream.Seek(6, SeekOrigin.Current);
+				CompressionMethod = (CompressionMethod)br.ReadUInt16();
+				br.BaseStream.Seek(8, SeekOrigin.Current);
+				CompressedSize = br.ReadUInt32();
+				UncompressedSize = br.ReadUInt32();
+				var fileNameLength = br.ReadUInt16();
+				var extraLength = br.ReadUInt16();
+				var commentLength = br.ReadUInt16();
+				br.BaseStream.Seek(8, SeekOrigin.Current);
+				FileOffset = br.ReadUInt32();
+				FileName = new string(br.ReadChars(fileNameLength));
+				br.BaseStream.Seek(extraLength + commentLength, SeekOrigin.Current);
+			}
+		}
+
+		private class EndOfCentralDirectoryEntry : ZipEntry
+		{
+			public uint CentralOffset { get; set; }
+
+			public EndOfCentralDirectoryEntry(BinaryReader br)
+			{
+				Offset = br.BaseStream.Position;
+				Type = ZipEntryType.EndOfCentralDirectory;
+
+				if (br.ReadUInt32() != (uint)ZipEntryType.EndOfCentralDirectory) throw new Exception("ZIP header is incorrect");
+
+				br.BaseStream.Seek(12, SeekOrigin.Current);
+				CentralOffset = br.ReadUInt32();
+
+				var commentLength = br.ReadUInt16();
+				br.BaseStream.Seek(commentLength, SeekOrigin.Current);
+			}
+		}
+
+		private enum ZipEntryType : uint
+		{
+			File = 0x04034b50,
+			DataDescriptor = 0x08074b50,
+			CentralDirectory = 0x02014b50,
+			EndOfCentralDirectory = 0x06054b50,
+		}
+
+		private enum CompressionMethod : ushort
+		{
+			None = 0, // The file is stored (no compression)
+			Shrink = 1, // The file is Shrunk
+			Compression1 = 2, // The file is Reduced with compression factor 1
+			Compression2 = 3, // The file is Reduced with compression factor 2
+			Compression3 = 4, // The file is Reduced with compression factor 3
+			Compression4 = 5, // The file is Reduced with compression factor 4
+			Imploded = 6, // The file is Imploded
+						  //　7, // Reserved for Tokenizing compression algorithm
+			Deflate = 8, // The file is Deflated
+			Deflate64 = 9, // Enhanced Deflating using Deflate64(tm)
+			IbmTerseOld = 10, // PKWARE Data Compression Library Imploding (old IBM TERSE)
+							  // 11, // Reserved by PKWARE
+			Bzip2 = 12, // File is compressed using BZIP2 algorithm
+						// 13, // Reserved by PKWARE
+			Lzma = 14, // LZMA (EFS)
+					   // 15, // Reserved by PKWARE
+					   // 16, // Reserved by PKWARE
+					   // 17, // Reserved by PKWARE
+			IbmTerse = 18, // File is compressed using IBM TERSE (new)
+			Lz77 = 19, // IBM LZ77 z Architecture (PFS)
+			WavPack = 97, // WavPack compressed data
+			Ppmd = 98, // PPMd version I, Rev 1
+		}
+	}
+}

--- a/Sledge.Packages/Zip/ZipEntry.cs
+++ b/Sledge.Packages/Zip/ZipEntry.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Drawing;
+
+namespace Sledge.Packages.Zip
+{
+    public class ZipEntry : IPackageEntry
+    {
+        public ZipPackage Package { get; private set; }
+
+        public string Path { get; private set; }
+        public string Name { get; }
+        public string FullName { get { return Path; } }
+        public string ParentPath { get { return GetParent(); } }
+        public long Length { get; private set; }
+        public ContentTypes ContentType { get; set; }
+        public int Width { get; }
+        public int Height { get; }
+
+        public MemoryStream StreamCopy
+        {
+            get
+            {
+                _streamCopy.Position = 0;
+                MemoryStream temp = new MemoryStream();
+                _streamCopy.CopyTo(temp);
+                return temp;
+            }
+        }
+
+        private readonly MemoryStream _streamCopy;
+
+        public ZipEntry(ZipPackage package, string path, Stream entry)
+        {
+            Package = package;
+            Length = entry.Length;
+
+            if (path.ToLowerInvariant().StartsWith("textures/"))
+			{
+				Path = System.IO.Path.ChangeExtension(path.ToLowerInvariant(), null);
+				Name = System.IO.Path.ChangeExtension(path.ToLowerInvariant(), null);
+				//Name = System.IO.Path.ChangeExtension(path.Substring(9).ToLowerInvariant(), null);
+			}
+            else
+            {
+                return;
+            }
+
+            if (path.EndsWith(".png"))
+            {
+				ContentType = ContentTypes.Png;
+			}
+			else if (path.EndsWith(".jpg"))
+			{
+				ContentType = ContentTypes.Jpg;
+			}
+			else if (path.EndsWith(".tga"))
+			{
+				ContentType = ContentTypes.Tga;
+			}
+
+			_streamCopy = new MemoryStream();
+	        entry.Position = 0;
+            entry.CopyTo(_streamCopy);
+            using (Image img = Image.FromStream(_streamCopy))
+            {
+                Width = img.Width;
+                Height = img.Height;
+            }
+        }
+
+        public Stream Open()
+        {
+            return Package.OpenStream(this);
+        }
+
+        private string GetParent()
+        {
+            var idx = Path.LastIndexOf('/');
+            if (idx < 0) return "";
+            return Path.Substring(0, idx);
+        }
+
+        public Stream GetStream()
+        {
+            return StreamCopy;
+		}
+
+		public enum ContentTypes
+		{
+			None,
+			Jpg,
+			Png,
+			Tga,
+			Md3
+		}
+	}
+}

--- a/Sledge.Packages/Zip/ZipPackage.cs
+++ b/Sledge.Packages/Zip/ZipPackage.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Sledge.Packages.Zip
+{
+    public class ZipPackage : IPackage
+    {
+        public FileInfo PackageFile { get; private set; }
+        internal List<ZipEntry> Entries { get; private set; }
+
+        public ZipPackage(FileInfo packageFile)
+        {
+            PackageFile = packageFile;
+            Entries = new List<ZipEntry>();
+
+			// Read the data from the .zip
+			using (ZipArchive br = new ZipArchive(OpenFile(packageFile)))
+            {
+                // Read all the entries from the .zip
+	            IEnumerable<string> entries = br.GetFiles();
+                foreach (string filePath in entries)
+                {
+	                string entryFixed = filePath.ToLowerInvariant();
+	                ZipEntry pe;
+                    switch (Path.GetExtension(entryFixed))
+					{
+						case ".png":
+						case ".jpg":
+						//case ".tga":
+						case ".md3":
+							MemoryStream fileStream = br.GetFileStream(filePath);
+                            pe = new ZipEntry(this, filePath, fileStream);
+							break;
+							//break;
+						default:
+							continue;
+					}
+
+					Entries.Add(pe);
+				}
+
+                BuildDirectories();
+            }
+        }
+
+        internal MemoryStream OpenFile(FileInfo file)
+        {
+			return new MemoryStream(File.ReadAllBytes(file.FullName));
+        }
+
+        public IEnumerable<IPackageEntry> GetEntries()
+        {
+            return Entries;
+        }
+
+        public IPackageEntry GetEntry(string path)
+        {
+            path = path.ToLowerInvariant();
+            return GetEntries().FirstOrDefault(x => x.FullName == path);
+        }
+
+        public byte[] ExtractEntry(IPackageEntry entry)
+        {
+            throw new Exception("Don't do this.");
+        }
+
+        public Stream OpenStream(IPackageEntry entry)
+        {
+            var pe = entry as ZipEntry;
+            if (pe == null) throw new ArgumentException("This package is only compatible with ZipEntry objects.");
+            return pe.GetStream();
+        }
+
+        public IPackageStreamSource GetStreamSource()
+        {
+            return new ZipPackageStreamSource(this);
+        }
+
+        public void Dispose()
+        {
+            Entries.Clear();
+        }
+        
+        private HashSet<string> _files;
+
+        private void BuildDirectories()
+        {
+            _files = new HashSet<string>();
+            foreach (var entry in GetEntries())
+            {
+                _files.Add(entry.Name);
+            }
+        }
+
+        public bool HasDirectory(string path)
+        {
+            return false;
+        }
+
+        public bool HasFile(string path)
+        {
+            return _files.Contains(path.ToLowerInvariant());
+        }
+
+        public IEnumerable<string> GetDirectories()
+        {
+            return new List<string>();
+        }
+
+        public IEnumerable<string> GetFiles()
+        {
+            return _files;
+        }
+
+        public IEnumerable<string> GetDirectories(string path)
+        {
+            return new string[0];
+        }
+
+        public IEnumerable<string> GetFiles(string path)
+        {
+            if (path != "")
+            {
+                return new List<string>();
+            }
+            return _files;
+        }
+
+        public IEnumerable<string> SearchDirectories(string path, string regex, bool recursive)
+        {
+            var files = recursive ? CollectDirectories(path) : GetDirectories(path);
+            return files.Where(x => Regex.IsMatch(GetName(x), regex, RegexOptions.IgnoreCase));
+        }
+
+        public IEnumerable<string> SearchFiles(string path, string regex, bool recursive)
+        {
+            var files = recursive ? CollectFiles(path) : GetFiles(path);
+            return files.Where(x => Regex.IsMatch(GetName(x), regex, RegexOptions.IgnoreCase));
+        }
+
+        private IEnumerable<string> CollectDirectories(string path)
+        {
+            return new List<string>();
+        }
+
+        private IEnumerable<string> CollectFiles(string path)
+        {
+            var files = new List<string>();
+            if (_files.Contains(path))
+            {
+                files.AddRange(_files);
+            }
+            return files;
+        }
+
+        private string GetName(string path)
+        {
+            return path;
+        }
+
+        public Stream OpenFile(string path)
+        {
+            var entry = GetEntry(path);
+            if (entry == null) throw new FileNotFoundException();
+            return OpenStream(entry);
+        }
+    }
+}

--- a/Sledge.Packages/Zip/ZipPackageStreamSource.cs
+++ b/Sledge.Packages/Zip/ZipPackageStreamSource.cs
@@ -1,0 +1,106 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Sledge.Packages.Zip
+{
+    internal class ZipPackageStreamSource : IPackageStreamSource
+    {
+        private readonly ZipPackage _package;
+        private readonly Stream _stream;
+        private readonly HashSet<string> _files;
+
+        public ZipPackageStreamSource(ZipPackage package)
+        {
+            _package = package;
+            _stream = package.OpenFile(package.PackageFile);
+            _files = new HashSet<string>();
+            foreach (var entry in package.GetEntries())
+            {
+                // File name
+                _files.Add(entry.Name);
+            }
+        }
+
+        private string GetName(string path)
+        {
+            return path;
+        }
+
+        public bool HasDirectory(string path)
+        {
+            if (path == "") return true;
+            return false;
+        }
+
+        public bool HasFile(string path)
+        {
+            var entry = GetEntry(path);
+            return entry != null;
+        }
+
+        public IEnumerable<string> GetDirectories()
+        {
+            return new List<string>();
+        }
+
+        public IEnumerable<string> GetFiles()
+        {
+            return _files;
+        }
+
+        public IEnumerable<string> GetDirectories(string path)
+        {
+            return new string[0];
+        }
+
+        public IEnumerable<string> GetFiles(string path)
+        {
+            return _files;
+        }
+
+        public IEnumerable<string> SearchDirectories(string path, string regex, bool recursive)
+        {
+            return _files.Where(x => Regex.IsMatch(GetName(x), regex, RegexOptions.IgnoreCase));
+        }
+
+        public IEnumerable<string> SearchFiles(string path, string regex, bool recursive)
+        {
+            return _files.Where(x => Regex.IsMatch(GetName(x), regex, RegexOptions.IgnoreCase));
+        }
+
+        private IEnumerable<string> CollectDirectories(string path)
+        {
+            return new string[0];
+        }
+
+        private IEnumerable<string> CollectFiles(string path)
+        {
+            return _files;
+        }
+
+        private ZipEntry GetEntry(string path)
+        {
+            path = path.ToLowerInvariant();
+            ZipEntry pe = _package.GetEntries().FirstOrDefault(x => x.Name == path) as ZipEntry;
+            return pe;
+        }
+
+        public Stream OpenFile(string path)
+        {
+            var entry = GetEntry(path);
+            if (entry == null)
+            {
+                throw new FileNotFoundException();
+            }
+
+            return entry.GetStream();
+        }
+
+        public void Dispose()
+        {
+            _stream.Dispose();
+        }
+    }
+}

--- a/Sledge.Providers/Sledge.Providers.csproj
+++ b/Sledge.Providers/Sledge.Providers.csproj
@@ -62,6 +62,7 @@
     <Compile Include="ProviderNotFoundException.cs" />
     <Compile Include="Map\RmfProvider.cs" />
     <Compile Include="Texture\NullTextureStreamSource.cs" />
+    <Compile Include="Texture\ZipProvider.cs" />
     <Compile Include="Texture\TextureSubItemType.cs" />
     <Compile Include="Texture\VmtProvider.cs" />
     <Compile Include="Texture\SpriteOrientation.cs" />

--- a/Sledge.Providers/Texture/ZipProvider.cs
+++ b/Sledge.Providers/Texture/ZipProvider.cs
@@ -1,0 +1,262 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.IO;
+using Sledge.Common;
+using Sledge.Graphics.Helpers;
+using System.Drawing;
+using Sledge.Packages;
+using Sledge.Packages.Zip;
+
+namespace Sledge.Providers.Texture
+{
+    public class ZipProvider : TextureProvider
+    {
+        public static bool ReplaceTransparentPixels = true;
+
+        private static Bitmap PostProcessBitmap(string packageName, string name, Bitmap bmp, out bool hasTransparency)
+        {
+            hasTransparency = false;
+            return bmp;
+        }
+
+        private const char NullCharacter = (char)0;
+
+        private bool LoadFromCache(TexturePackage package)
+        {
+            if (CachePath == null || !Directory.Exists(CachePath)) return false;
+
+            var fi = new FileInfo(package.PackageRoot);
+            var cacheFile = Path.Combine(CachePath, fi.Name + "_" + (fi.LastWriteTime.Ticks));
+            if (!File.Exists(cacheFile)) return false;
+
+            var lines = File.ReadAllLines(cacheFile);
+            if (lines.Length < 3) return false;
+            if (lines[0] != fi.FullName) return false;
+            if (lines[1] != fi.LastWriteTime.ToFileTime().ToString(CultureInfo.InvariantCulture)) return false;
+            if (lines[2] != fi.Length.ToString(CultureInfo.InvariantCulture)) return false;
+
+            try
+            {
+                var items = new List<TextureItem>();
+                foreach (var line in lines.Skip(3))
+                {
+                    var spl = line.Split(NullCharacter);
+                    items.Add(new TextureItem(package, spl[0], GetFlags(spl[0]), int.Parse(spl[1], CultureInfo.InvariantCulture), int.Parse(spl[2], CultureInfo.InvariantCulture)));
+                }
+                items.ForEach(package.AddTexture);
+            }
+            catch
+            {
+                // Cache file is no good...
+                return false;
+            }
+            return true;
+        }
+
+        // TODO: Figure out how id Tech 3 handles this stuff.
+        private TextureFlags GetFlags(string name)
+        {
+            var flags = TextureFlags.None;
+            //var tp = ReplaceTransparentPixels && name.StartsWith("{");
+            //if (tp) flags |= TextureFlags.Transparent;
+            return flags;
+        }
+
+        private void SaveToCache(TexturePackage package)
+        {
+            if (CachePath == null || !Directory.Exists(CachePath)) return;
+            var fi = new FileInfo(package.PackageRoot);
+            var cacheFile = Path.Combine(CachePath, fi.Name + "_" + (fi.LastWriteTime.Ticks));
+            var lines = new List<string>();
+            lines.Add(fi.FullName);
+            lines.Add(fi.LastWriteTime.ToFileTime().ToString(CultureInfo.InvariantCulture));
+            lines.Add(fi.Length.ToString(CultureInfo.InvariantCulture));
+            foreach (var ti in package.Items.Values)
+            {
+                lines.Add(ti.Name + NullCharacter + ti.Width.ToString(CultureInfo.InvariantCulture) + NullCharacter + ti.Height.ToString(CultureInfo.InvariantCulture));
+            }
+            File.WriteAllLines(cacheFile, lines);
+        }
+
+        private readonly Dictionary<TexturePackage, ZipStream> _roots = new Dictionary<TexturePackage, ZipStream>();
+
+        private TexturePackage CreatePackage(string package)
+        {
+            try
+            {
+                var fi = new FileInfo(package);
+                if (!fi.Exists) return null;
+
+                var tp = new TexturePackage(package, Path.GetFileNameWithoutExtension(package), this);
+                if (LoadFromCache(tp)) return tp;
+
+                var list = new List<TextureItem>();
+
+                var pack = _roots.Values.FirstOrDefault(x => x.Package.PackageFile.FullName == fi.FullName);
+                if (pack == null) _roots.Add(tp, pack = new ZipStream(new ZipPackage(fi)));
+
+                list.AddRange(pack.Package.GetEntries().OfType<ZipEntry>().Where(x => x.ContentType != ZipEntry.ContentTypes.None).Select(x => new TextureItem(tp, x.Name, GetFlags(x.Name), x.Width, x.Height)));
+                foreach (var ti in list)
+                {
+                    tp.AddTexture(ti);
+                }
+                SaveToCache(tp);
+                return tp;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public override IEnumerable<TexturePackage> CreatePackages(IEnumerable<string> sourceRoots, IEnumerable<string> additionalPackages, IEnumerable<string> blacklist, IEnumerable<string> whitelist)
+        {
+            var blist = blacklist.Select(x => x.EndsWith(".pk3") ? x.Substring(0, x.Length - 4) : x).Where(x => !String.IsNullOrWhiteSpace(x)).ToList();
+            var wlist = whitelist.Select(x => x.EndsWith(".pk3") ? x.Substring(0, x.Length - 4) : x).Where(x => !String.IsNullOrWhiteSpace(x)).ToList();
+            var pk3s = sourceRoots.Union(additionalPackages)
+                .Where(Directory.Exists)
+                .SelectMany(x => Directory.GetFiles(x, "*.pk3", SearchOption.TopDirectoryOnly))
+                .Union(additionalPackages.Where(x => x.EndsWith(".pk3") && File.Exists(x)))
+                .GroupBy(Path.GetFileNameWithoutExtension)
+                .Select(x => x.First())
+                .Where(x => !blist.Any(b => String.Equals(Path.GetFileNameWithoutExtension(x) ?? x, b, StringComparison.InvariantCultureIgnoreCase)));
+            if (wlist.Any())
+            {
+                pk3s = pk3s.Where(x => wlist.Contains(Path.GetFileNameWithoutExtension(x) ?? x, StringComparer.InvariantCultureIgnoreCase));
+            }
+            return pk3s.AsParallel().Select(CreatePackage).Where(x => x != null);
+        }
+
+        public override void DeletePackages(IEnumerable<TexturePackage> packages)
+        {
+            var packs = packages.ToList();
+            var roots = _roots.Where(x => packs.Contains(x.Key)).Select(x => x.Value).ToList();
+            foreach (var tp in packs)
+            {
+                _roots.Remove(tp);
+            }
+            foreach (var root in roots.Where(x => !_roots.ContainsValue(x)))
+            {
+                root.Dispose();
+            }
+        }
+
+        public override void LoadTextures(IEnumerable<TextureItem> items)
+        {
+            var list = items.ToList();
+            var packages = list.Select(x => x.Package).Distinct().ToList();
+            var packs = packages.Select(x =>
+            {
+                if (!_roots.ContainsKey(x))
+                {
+                    var wp = new ZipStream(new ZipPackage(new FileInfo(x.PackageRoot)));
+                    _roots.Add(x, wp);
+                }
+                return _roots[x];
+
+            }).ToList();
+            var streams = packs.Select(x => x.StreamSource).ToList();
+
+            // Process the bitmaps in parallel
+            var bitmaps = list.AsParallel().Select(ti =>
+            {
+                var stream = streams.FirstOrDefault(x => PackageHasTexture(x, ti.Name));
+                if (stream == null) return null;
+
+                var open = stream.OpenFile($"textures/{ti.Name.ToLowerInvariant()}");
+                if (open == null) return null;
+
+                var bmp = new Bitmap(open);
+                bool hasTransparency;
+                bmp = PostProcessBitmap(ti.Package.PackageRelativePath, ti.Name.ToLowerInvariant(), bmp, out hasTransparency);
+                open.Dispose();
+
+                return new
+                {
+                    Bitmap = bmp,
+                    Name = ti.Name.ToLowerInvariant(),
+                    ti.Width,
+                    ti.Height,
+                    ti.Flags
+                };
+            }).Where(x => x != null);
+
+            // TextureHelper.Create must run on the UI thread
+            foreach (var bmp in bitmaps)
+            {
+                TextureHelper.Create(bmp.Name, bmp.Bitmap, bmp.Width, bmp.Height, bmp.Flags);
+                bmp.Bitmap.Dispose();
+            }
+        }
+
+	    private static bool PackageHasTexture(IPackageStreamSource package, string name)
+	    {
+		    return package.HasFile($"textures/{name.ToLowerInvariant()}");
+	    }
+
+	    public override ITextureStreamSource GetStreamSource(int maxWidth, int maxHeight, IEnumerable<TexturePackage> packages)
+        {
+            var packs = packages.Select(x =>
+            {
+                if (!_roots.ContainsKey(x))
+                {
+                    var wp = new ZipStream(new ZipPackage(new FileInfo(x.PackageRoot)));
+                    _roots.Add(x, wp);
+                }
+                return _roots[x];
+
+            }).ToList();
+            var streams = packs.Select(x => x.StreamSource).ToList();
+            return new ZipStreamSource(streams);
+        }
+
+        private class ZipStreamSource : ITextureStreamSource
+        {
+            private readonly List<IPackageStreamSource> _streams;
+
+            public ZipStreamSource(IEnumerable<IPackageStreamSource> streams)
+            {
+                _streams = streams.ToList();
+            }
+
+            public bool HasImage(TextureItem item)
+            {
+                return _streams.Any(x => PackageHasTexture(x, item.Name));
+            }
+
+            public Bitmap GetImage(TextureItem item)
+            {
+                using (var stream = _streams.First(x => PackageHasTexture(x, item.Name)).OpenFile($"textures/{item.Name.ToLowerInvariant()}"))
+                {
+                    bool hasTransparency;
+                    return PostProcessBitmap(item.Package.PackageRelativePath, item.Name.ToLowerInvariant(), new Bitmap(stream), out hasTransparency);
+                }
+            }
+
+            public void Dispose()
+            {
+
+            }
+        }
+
+        private class ZipStream : IDisposable
+        {
+            public ZipPackage Package { get; set; }
+            public IPackageStreamSource StreamSource { get; private set; }
+
+            public ZipStream(ZipPackage package)
+            {
+                Package = package;
+                StreamSource = package.GetStreamSource();
+            }
+
+            public void Dispose()
+            {
+                StreamSource.Dispose();
+                Package.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Laying groundwork for id Tech 3 (/ioquake3/Spearmint) support.
I had to bump the .NET Framework used up to 4.5 in order to get the improved .zip support. Otherwise we'd have to bring in an external .zip reader. I'll add .tga support later; I didn't know off the top of my head if they were supported by .NET's Image and Bitmap classes. .pk3 loading is a bit slow. I'll improve that later.