### PR TITLE
Fix .mdl loading trying to get the extension of a null file.

### DIFF
--- a/Sledge.Providers/Model/MdlProvider.cs
+++ b/Sledge.Providers/Model/MdlProvider.cs
@@ -40,7 +40,11 @@ namespace Sledge.Providers.Model
     {
         protected override bool IsValidForFile(IFile file)
         {
-            return file.Extension.ToLowerInvariant() == "mdl";
+            if (file != null)
+            {
+                return file.Extension.ToLowerInvariant() == "mdl";
+            }
+            return false;
         }
 
         protected override DataStructures.Models.Model LoadFromFile(IFile file)


### PR DESCRIPTION
When trying to load my Quake 3 maps, Sledge tries to find the extension of a null file. I don't know if this is the proper fix or not, but it stopped Sledge from throwing an exception.
