### PR TITLE
Fixed NaN problems when navigating camera in 3D view.

### DIFF
--- a/Sledge.Rendering/Cameras/PerspectiveCamera.cs
+++ b/Sledge.Rendering/Cameras/PerspectiveCamera.cs
@@ -213,7 +213,10 @@ namespace Sledge.Rendering.Cameras
         public float GetRotation()
         {
             var temp = (LookAt - Position);
-            temp.Normalize();
+            if (temp.Length != 0)
+            {
+                temp.Normalize();
+            }
             var rot = Math.Atan2(temp.Y, temp.X);
             if (rot < 0) rot += 2 * Math.PI;
             if (rot > 2 * Math.PI) rot = rot % (2 * Math.PI);
@@ -223,7 +226,10 @@ namespace Sledge.Rendering.Cameras
         public void SetRotation(float rotation)
         {
             var temp = (LookAt - Position);
-            temp.Normalize();
+            if (temp.Length != 0)
+            {
+                temp.Normalize();
+            }
             var e = GetElevation();
             var x = Math.Cos(rotation) * Math.Sin(e);
             var y = Math.Sin(rotation) * Math.Sin(e);
@@ -233,7 +239,10 @@ namespace Sledge.Rendering.Cameras
         public float GetElevation()
         {
             var temp = (LookAt - Position);
-            temp.Normalize();
+            if (temp.Length != 0)
+            {
+                temp.Normalize();
+            }
             var elev = Math.Acos(temp.Z);
             return (float)elev;
         }


### PR DESCRIPTION
Found a problem when navigating the camera in 3D view. This was reproducible with a map of my archive every time after loading the map and navigating the camera. I was unable to do anything in 3D view. Therefore I propose this fix. The vectors must not be normalized when length equals 0.