### PR TITLE
Fix exponential easing function

### DIFF
--- a/Sledge.Common/Easings/Easing.cs
+++ b/Sledge.Common/Easings/Easing.cs
@@ -57,9 +57,9 @@ namespace Sledge.Common.Easings
                 case EasingType.Quintic:
                     return x => Math.Pow(x, 5);
                 case EasingType.Sinusoidal:
-                    return x => 1 - Math.Cos(x * Math.PI / 2); // Wait... That's not Sine!
+                    return x => 1 - Math.Cos(x * Math.PI / 2);
                 case EasingType.Exponential:
-                    return x => Math.Pow(x, 5);
+                    return x => Math.Pow(2, x) - 1;
                 case EasingType.Circular:
                     return x => 1 - Math.Sqrt(1 - x * x);
                 default:

--- a/Sledge.Common/Easings/Easing.cs
+++ b/Sledge.Common/Easings/Easing.cs
@@ -59,7 +59,7 @@ namespace Sledge.Common.Easings
                 case EasingType.Sinusoidal:
                     return x => 1 - Math.Cos(x * Math.PI / 2);
                 case EasingType.Exponential:
-                    return x => Math.Pow(2, x) - 1;
+                    return x => Math.Pow(2, 10*(x-1));
                 case EasingType.Circular:
                     return x => 1 - Math.Sqrt(1 - x * x);
                 default:


### PR DESCRIPTION
To actually be exponential. The base is arbitrary but it works as long as
<a href="https://www.codecogs.com/eqnedit.php?latex=a^x&space;-&space;\frac{a}{2}" target="_blank"><img src="https://latex.codecogs.com/gif.latex?a^x&space;-&space;\frac{a}{2}" title="a^x - \frac{a}{2}" /></a>


Also, sinusoidal means sine-like. It's a wave crest shifted upwards to be positive :)